### PR TITLE
Adding a terms (list of tags)

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,0 +1,35 @@
+{{ partial "header.html" . }}
+
+{{ partial "navbar.html" . }}
+
+<div class="tags-list">
+  <h1><center><i class="fas fa-tags"></i> {{ .Title }}</center></h1>
+
+  <!-- create a list with all uppercase letters -->
+  {{ $letters := split "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "" }}
+
+  <!-- range all pages sorted by their title -->
+  <span class="tags">{{ range sort .Site.Taxonomies.tags }}</span><br />
+  <!-- get the first character of each title. Assumes that the title is never empty! -->
+  {{ $firstChar := substr .Page.Title 0 1 | upper }}
+
+  <!-- in case $firstChar is a letter -->
+  {{ if $firstChar | in $letters }}
+    <!-- get the current letter -->
+    {{ $curLetter := $.Scratch.Get "curLetter" }}
+  <!-- if $curLetter isn't set or the letter has changed -->
+  {{ if ne $firstChar $curLetter }}
+    <!-- update the current letter and print it -->
+    {{ $.Scratch.Set "curLetter" $firstChar }}
+
+  <br /><span class="letter">{{ $firstChar }}</span><br />
+  {{ end }}
+
+  <a class="badge badge-tag-list-page" href="{{ .Page.Permalink }}"><i class="fas fa-tags"></i> {{ .Page.Title }} ({{ .Count }})</a>
+  {{ end }}
+  {{ end }}
+</div>
+
+<!-- grabbed from https://gitlab.com/gsalvatovallverdu/gsalvatovallverdu.gitlab.io/-/blob/master/layouts/_default/terms.html -->
+
+{{ partial "footer.html" . }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -2,34 +2,21 @@
 
 {{ partial "navbar.html" . }}
 
-<div class="tags-list">
-  <h1><center><i class="fas fa-tags"></i> {{ .Title }}</center></h1>
+<section class="section work">
+	{{ partial "helpers/hidden-menu.html" . }}
 
-  <!-- create a list with all uppercase letters -->
-  {{ $letters := split "ABCDEFGHIJKLMNOPQRSTUVWXYZ" "" }}
-
-  <!-- range all pages sorted by their title -->
-  <span class="tags">{{ range sort .Site.Taxonomies.tags }}</span><br />
-  <!-- get the first character of each title. Assumes that the title is never empty! -->
-  {{ $firstChar := substr .Page.Title 0 1 | upper }}
-
-  <!-- in case $firstChar is a letter -->
-  {{ if $firstChar | in $letters }}
-    <!-- get the current letter -->
-    {{ $curLetter := $.Scratch.Get "curLetter" }}
-  <!-- if $curLetter isn't set or the letter has changed -->
-  {{ if ne $firstChar $curLetter }}
-    <!-- update the current letter and print it -->
-    {{ $.Scratch.Set "curLetter" $firstChar }}
-
-  <br /><span class="letter">{{ $firstChar }}</span><br />
-  {{ end }}
-
-  <a class="badge badge-tag-list-page" href="{{ .Page.Permalink }}"><i class="fas fa-tags"></i> {{ .Page.Title }} ({{ .Count }})</a>
-  {{ end }}
-  {{ end }}
-</div>
-
-<!-- grabbed from https://gitlab.com/gsalvatovallverdu/gsalvatovallverdu.gitlab.io/-/blob/master/layouts/_default/terms.html -->
+	<div class="columns is-multiline mt-2">
+		{{ range sort .Site.Taxonomies.tags "Count" "desc" }}
+			<div class="column is-half center">
+				<div class="slide-tag">
+					<a href="{{ .Page.Permalink }}">
+						<i class="fas fa-tags"></i>
+						{{ .Page.Title }} ({{ .Count }})
+					</a>
+				</div>
+			</div>
+		{{ end }}
+	</div>
+</section>
 
 {{ partial "footer.html" . }}

--- a/layouts/partials/slides/meta.html
+++ b/layouts/partials/slides/meta.html
@@ -19,10 +19,13 @@
                     <p>{{ .ctx.Page.Date.Format "January 2, 2006" }}</p>
                 </div>
             {{ else }}
-                <div class="center column slide-meta-el grey">
-                    <p>{{ with (index $.imgs 0).Exif }}{{ .Date.Format "January 2, 2006" }}</p>
+                {{ with (index $.imgs 0).Exif }}
+                    {{ with .Date.Format }}
+                        <div class="center column slide-meta-el grey">
+                            <p>{{ . "January 2, 2006" }}</p>
+                        </div>
                     {{ end }}
-                </div>
+                {{ end }}
             {{ end }}
         {{ end }}
     </div>

--- a/layouts/partials/slides/meta.html
+++ b/layouts/partials/slides/meta.html
@@ -20,7 +20,8 @@
                 </div>
             {{ else }}
                 <div class="center column slide-meta-el grey">
-                    <p>{{ with (index $.imgs 0).Exif }}</p>{{ .Date.Format "January 2, 2006" }}</p>{{ end }}</p>
+                    <p>{{ with (index $.imgs 0).Exif }}{{ .Date.Format "January 2, 2006" }}</p>
+                    {{ end }}
                 </div>
             {{ end }}
         {{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -383,3 +383,8 @@ section .column img {
         margin-top: 0;
     }
 }
+
+.tags-list {
+     margin: 0 auto;
+     width: 600px;
+}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -264,6 +264,10 @@ section .column img {
     padding-left: 3px;
 }
 
+.slide-tag {
+    font-size: medium;
+}
+
 .grey {
     color: var(--grey);
 }
@@ -382,9 +386,4 @@ section .column img {
     100% {
         margin-top: 0;
     }
-}
-
-.tags-list {
-     margin: 0 auto;
-     width: 600px;
 }


### PR DESCRIPTION
I've created a terms.html to have a list of all my tags, ranged alphabetically with grouping by first letter.

My inspiration comes from this [repo](https://gitlab.com/gsalvatovallverdu/gsalvatovallverdu.gitlab.io/-/blob/master/layouts/_default/terms.html)

Here's the result into my website :
![image](https://user-images.githubusercontent.com/28442699/195828956-77b763e0-1446-4267-a635-2194955c5818.png)

You are free to change the style's parameters for the default theme configuration if you're interested with this PR