### PR TITLE
Landing pics

### DIFF
--- a/example/eternity.bora.sh/content/_index.md
+++ b/example/eternity.bora.sh/content/_index.md
@@ -4,9 +4,9 @@ desc:
 - designed for portfolio sites with a fresh feel.
 featuredTags:
   - title: people
-    image: https://source.unsplash.com/random?people&26027020
+    image: https://source.unsplash.com/random?people&1649630128
     url: /tags/people/
   - title: nature
-    image: /2020/IMG_1092.jpg
-    url: https://source.unsplash.com/random?nature&2031821204
+    image: https://source.unsplash.com/random?nature&17346933
+    url: /tags/nature/
 ---

--- a/example/eternity.bora.sh/content/_index.md
+++ b/example/eternity.bora.sh/content/_index.md
@@ -2,5 +2,11 @@
 desc:
 - Eternity is a minimalist Hugo theme
 - designed for portfolio sites with a fresh feel.
+featuredTags:
+  - title: people
+    image: https://source.unsplash.com/random?people&26027020
+    url: /tags/people/
+  - title: nature
+    image: /2020/IMG_1092.jpg
+    url: https://source.unsplash.com/random?nature&2031821204
 ---
- 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -20,7 +20,10 @@
 						<div class="column">
 							<a href="{{ .url }}">
 								<div class="image-box">
-									{{ $image := resources.Get .image }}
+									{{ $scratch := newScratch }}
+									{{ $row := dict "images" (slice .image) }}
+									{{ partial "helpers/get" (dict "scratch" $scratch "row" $row) }}
+									{{ $image := $scratch.Get "img" }}
 									{{ with $image }}
 									<img src="{{ $image.RelPermalink }}" loading="lazy" />
 									{{end}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -14,6 +14,23 @@
 				<button onclick="window.location.href='{{ relref . .Site.Params.Homepage }}'"
 				class="button is-white is-large is-outlined">enter</button>
 			</div>
+			<div class="enter">
+				<div class="columns">
+					{{ range .Params.FeaturedTags }}
+						<div class="column">
+							<a href="{{ .url }}">
+								<div class="image-box">
+									{{ $image := resources.Get .image }}
+									{{ with $image }}
+									<img src="{{ $image.RelPermalink }}" loading="lazy" />
+									{{end}}
+									<h3>{{ .title }}</h3>
+								</div>
+							</a>
+						</div>
+					{{ end }}
+				</div>
+			</div>
 			{{ range $d := .Params.Desc }}
 				<p>{{ $d }}</p>
 			{{ end }}

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -117,7 +117,6 @@ img.logo {
 
 .welcome-end {
     width: 100%;
-    position: absolute;
     padding: 20px;
     bottom: 0;
     text-align: center;


### PR DESCRIPTION
Hello,
for my own website, I needed a capability to add some pictures on the welcome page, with direct links to some "featured" tags.

Here is a proposal to optionally add in the main _index.html a "featuredTags:" parameter that will achieve this:
![featuredTags Sample](https://user-images.githubusercontent.com/2265539/197156499-327f69ab-e798-4099-9053-83040d0186a1.png)
 when the "featuredTags" parameter is not provided, the default layout is used, without any change compared to the current standard layout.

Let me know what do you think about this, and if such feature could be integrated in the main branch.
