### PR TITLE
invert logo's link behavior

### DIFF
--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -1,5 +1,5 @@
 {{ $homeLink := .Site.Params.Homepage }}
-{{ if .IsHome }}
+{{ if not .IsHome }}
     {{ $homeLink = "/" }}
 {{ end }}
 <nav class="navbar" role="navigation" aria-label="main navigation">


### PR DESCRIPTION
When clicking on the top-left logo, the link seems not to be working as it actually targets the current page ... which I think is kind of useless.
I was not sure of the expected behavior here, but I find it more convenient to have the opposite behavior than what is currently working.

This Pull Request is then opened to confirm what you were intending to link from the logo; and confirm the current behavior or invert it if you think that this is more convenient, as I do.