### PR TITLE
Introduce option to add attribute rel="me" to social links

### DIFF
--- a/doc/config.md
+++ b/doc/config.md
@@ -97,7 +97,7 @@ params:
   disableRadius: true
 ```
 
-You can move Title and Meta down, to show them only when scroll.
+You can move Title and Meta down, to show them only when scroll.  
 ```yaml
 params:
   moveIt: true

--- a/doc/config.md
+++ b/doc/config.md
@@ -97,7 +97,7 @@ params:
   disableRadius: true
 ```
 
-You can move Title and Meta down, to show them only when scroll.  
+You can move Title and Meta down, to show them only when scroll.
 ```yaml
 params:
   moveIt: true

--- a/doc/config.md
+++ b/doc/config.md
@@ -50,7 +50,12 @@ params:
         people: 1
 ```
 
-You can use `socials` array to set your social accounts. `icon` is font-awesome icon code. You can use `landing` variable to make icon invisible only for landing page but visible inside website.
+You can use `socials` array to set your social accounts.
+
+- `icon` is a font-awesome icon code.
+- `landing: true` makes an icon invisible on the landing page but visible inside website.
+- `rel_me: true` adds the HTML attribute `rel="me"` to the link. This is useful to verify the link to your Mastodon profile.
+
 ```yaml
 params:
   socials:

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -37,7 +37,7 @@
             {{ end }}
             {{ range $el := $socials }}
                 <div class="social">
-                    <a href="{{ $el.url }}" target="_blank">
+                    <a href="{{ $el.url }}" {{ if $el.rel_me }} rel="me" {{ end }} target="_blank">
                         <i class="{{ $el.icon }}"></i>
                     </a>
                 </div>


### PR DESCRIPTION
Fediverse services such as Mastodon verify ownership of URLs by looking
at a link of the following shape in a web site:
<a href="https://your.mastodon.tld/@profile" rel="me">...</a>

See here for official documentation:
https://docs.joinmastodon.org/user/profile/#verification

This change adds the "rel_me" boolean option for elements in the
"socials" section. If set to "true", the attribute will be added to the
respective <a> link tag.