### PR TITLE
feat(welcompage): add option to disable background image

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -27,6 +27,7 @@ params:
     - archive
   bypassWelcomePage: false # redirects "/" to "homepage" when it's true.
   plausible: '' # todo: set your plausible id.
+  disableWelcomePageBackground: false # disables the background image on the homepage
   disableRadius: false
   moveIt: false # Moves Title and Meta info down, only visible when scroll.
   disableAlwaysResize: false

--- a/doc/config.md
+++ b/doc/config.md
@@ -91,6 +91,12 @@ params:
   bypassWelcomePage: true
 ```
 
+You can disable the background image on the welcome page.
+```yaml
+params:
+  disableWelcomePageBackground: false
+```
+
 You can disable logo's radius with `disableRadius` variable.
 ```yaml
 params:
@@ -103,7 +109,7 @@ params:
   disableAlwaysResize: true
 ```
 
-You can move Title and Meta down, to show them only when scroll.  
+You can move Title and Meta down, to show them only when scroll.
 ```yaml
 params:
   moveIt: true

--- a/example/eternity.bora.sh/config.yaml
+++ b/example/eternity.bora.sh/config.yaml
@@ -38,6 +38,7 @@ params:
     - work
     - archive
   bypassWelcomePage: false # redirects "/" to "homepage" when it's true.
+  disableWelcomePageBackground: false # disables the background image on the homepage
   plausible: '' # todo: set your plausible id.
   disableRadius: false
   moveIt: false  # Moves Title and Meta info down, only visible when scroll.

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -6,7 +6,7 @@
 </head>
 {{ else }}
 <section class="hero is-fullheight welcome"
-	style="background-image: url({{ "background.jpeg" | absURL }});">
+  {{ if not .Site.Params.DisableWelcomePageBackground }} style="background-image: url({{ "background.jpeg" | absURL }});" {{ end }}>
 	{{ partial "navbar.html" . }}
 	<div class="hero-body has-text-centered">
 		<div class="container">


### PR DESCRIPTION
It would be nice to make the background image on the welcome page optional. I added an option for this, so it can be done in the config file. The default is enabled, so it won't break existing websites that are upgrading. I also updated the documentation and example. 

I hope you find this a useful addition.