### PR TITLE
Brightness isn't always a decimal

### DIFF
--- a/layouts/partials/helpers/exif.html
+++ b/layouts/partials/helpers/exif.html
@@ -5,7 +5,7 @@
             {{ with .Date }}<li>Date: {{ .Format "January 2, 2006" }}</li>{{ end }}
             {{ with .Tags.Copyright }}<li>Copyright: {{ . }}</li>{{ end }}
             {{ with .Tags.ApertureValue }}<li>Aperture: {{ lang.NumFmt 2 . }}</li>{{ end }}
-            {{ with .Tags.BrightnessValue }}<li>Brightness: {{ lang.NumFmt 2 . }}</li>{{ end }}
+            {{ with .Tags.BrightnessValue }}<li>Brightness: {{ . }}</li>{{ end }}
             {{ with .Tags.ExposureTime }}<li>Exposure Time: {{ . }}</li>{{ end }}
             {{ with .Tags.FNumber }}<li>F Number: {{ . }}</li>{{ end }}
             {{ with .Tags.FocalLength }}<li>Focal Length: {{ . }}</li>{{ end }}


### PR DESCRIPTION
Sometimes brightness is a fraction, like "1/5" and so it's handled like a string. A general solution to look for fractions and convert to decimal may be preferable, but a general solution of just not trying to do the NumFmt may make as much sense.