### PR TITLE
Add config option for logo

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,6 +6,7 @@ googleAnalytics: '' # todo: set your analytics id.
 
 params:
   image: /images/banner.png
+  logo: /images/logo.png
   subtitle: Eternity is a minimalist Hugo theme designed for portfolio sites with a fresh feel. # todo: change default subtitle for your website.
   copyright: All rights reserved. # todo: set your copyright type.
   author: Lovely Author # todo: set your full name.

--- a/example/eternity.bora.sh/config.yaml
+++ b/example/eternity.bora.sh/config.yaml
@@ -6,6 +6,7 @@ googleAnalytics: '' # todo: set your analytics id.
 
 params:
   image: /images/banner.png
+  logo: /logo.png
   subtitle: Eternity is a minimalist Hugo theme designed for portfolio sites with a fresh feel. # todo: change default subtitle for your website.
   copyright: All rights reserved. # todo: set your copyright type.
   author: Lovely Author # todo: set your full name.

--- a/layouts/partials/navbar.html
+++ b/layouts/partials/navbar.html
@@ -6,7 +6,7 @@
     <div class="navbar-start">
         <div class="logo">
             <a href={{ relref . $homeLink }}>
-                <img class="logo" src={{ "logo.png" | absURL }}>
+                <img class="logo" src={{ .Site.Params.logo | absURL }}>
             </a>
         </div>
     </div>


### PR DESCRIPTION
Minor, backwards-compatible change that sets the logo through a config option. This is helpful, for example, if you want to use a logo that is not a png.

This change will have no effect on a default installation, as it replaces a hardcoded path with a variable pointing to the same place.