### PR TITLE
Add support for custom css, and a spelling update

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Note: If you're an artist who wants to host a website but doesn't have know how 
 
 - Integrated **lazy load**.
 
-- Automaticly creates **resized** thumbnails.
+- Automatically creates **resized** thumbnails.
 
 - Shows **exif** if it exists.
 

--- a/doc/style.md
+++ b/doc/style.md
@@ -18,3 +18,8 @@ Create [**/static/css/width.css**](/static/css/width.css) in your repo to be abl
 ### Change font
 
 Create [**/layouts/partials/fonts.html**](/layouts/partials/fonts.html) in your repo to be able to change fonts.
+
+### Advanced customization
+
+Create [**/static/css/custom.css**](/static/css/custom.css) in your repo to be able to add or override CSS directives.
+

--- a/example/eternity.bora.sh/content/about.md
+++ b/example/eternity.bora.sh/content/about.md
@@ -27,7 +27,7 @@ hideDate: true
 
 - Integrated **lazy load**.
 
-- Automaticly creates **resized** thumbnails.
+- Automatically creates **resized** thumbnails.
 
 - Shows **exif** if it exists.
 

--- a/example/eternity.bora.sh/content/work/_index.md
+++ b/example/eternity.bora.sh/content/work/_index.md
@@ -22,7 +22,7 @@ url: work
 
 - Integrated **lazy load**.
 
-- Automaticly creates **resized** thumbnails.
+- Automatically creates **resized** thumbnails.
 
 - Shows **exif** if it exists.
 

--- a/static/css/custom.css
+++ b/static/css/custom.css
@@ -1,0 +1,1 @@
+/* Custom CSS styles */

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -7,3 +7,4 @@
 @import "style.css";
 @import "tablet.css";
 @import "mobile.css";
+@import "custom.css";


### PR DESCRIPTION
I'd like to suggest another minor change that adds support for a generic `custom.css` file. The intent is for it to be used for overrides or more extensive customization, without messing with the `width.css` or `colors.css` files.

This PR also includes a minor update in the documentation.