### PR TITLE
Move inline styles to CSS

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -5,8 +5,7 @@
 	<meta http-equiv="refresh" content="0; URL={{ relref . .Site.Params.Homepage }}" />
 </head>
 {{ else }}
-<section class="hero is-fullheight welcome"
-  {{ if not .Site.Params.DisableWelcomePageBackground }} style="background-image: url({{ "background.jpeg" | absURL }});" {{ end }}>
+<section class="hero is-fullheight welcome {{ if not .Site.Params.DisableWelcomePageBackground }}welcome-image{{ end }}">
 	{{ partial "navbar.html" . }}
 	<div class="hero-body has-text-centered">
 		<div class="container">

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -6,7 +6,10 @@
 /* WELCOME */
 
 .welcome {
-    /* background-image: url("/background.jpeg"); It was moved to inline css. */
+}
+
+.welcome-image {
+    background: url("/background.jpeg");
     background-size: cover;
     background-position: center;
     width: 100%;


### PR DESCRIPTION
Another minor contribution to increase the flexibility of the theme. The background image config was an inline style. This change migrates the style into a stylesheet in a backward-compatible way, which would make it easier to override in custom CSS.