### PR TITLE
feature: Image captions or subtitles for images

### DIFF
--- a/doc/posts.md
+++ b/doc/posts.md
@@ -33,13 +33,31 @@ date: 2022-07-24
 
 You can use multiple images by adding them to `images` array. Default view is `row`. But if you want to set them as `column`, you can use `multipleColumn` value. Both local images and remote images are supported. If you use remote image, it will be downloaded.
 
-
 ```yaml
 ---
 weight: 9
 images:
 - /images/my-image-1.jpg
 - /images/my-image-2.jpg
+multipleColumn: true
+title: Here's my first post!!
+tags:
+- work
+- first
+date: 2022-07-24
+---
+```
+
+You can also specify a caption or subtitle for each of your images. Use `captions`array in that case. It must match the length an order of `images` if used:
+```yaml
+---
+weight: 9
+images:
+- /images/my-image-1.jpg
+- /images/my-image-2.jpg
+captions:
+- Incredible view at Nowhere City
+- Nowhere City Lake
 multipleColumn: true
 title: Here's my first post!!
 tags:

--- a/layouts/partials/slides/slide.html
+++ b/layouts/partials/slides/slide.html
@@ -6,6 +6,13 @@
 	{{ $imgs = $imgs | append ($scratch.Get "img") }}
 {{ end }}
 
+{{ $captions := slice }}
+{{ range $i, $caption := .ctx.Params.captions }}
+	{{ print $caption }}
+	{{ $captions = $captions | append ($caption) }}
+{{ end }}
+
+
 {{ $includesInfo := false }}
 {{ if or (and (gt (len $imgs) 1) (not .ctx.Params.multipleColumn)) (gt (len .ctx.Content) 0) }}
 	{{ $includesInfo = true }}
@@ -27,7 +34,10 @@
 							{{ $img = $img.Resize "3000x" }}
 						{{ end  }}
 						<div {{ if $.ctx.Params.multipleColumn }} class="column" {{ end }}>
-							<img src="{{ $img.RelPermalink }}" loading="lazy" width="{{ $img.Width }}" height="{{ $img.Height }}" />
+							<figure>
+								<img src="{{ $img.RelPermalink }}" loading="lazy" width="{{ $img.Width }}" height="{{ $img.Height }}" />
+								<figcaption class="caption">{{ index $captions $i }}</figcaption>
+							</figure>
 						</div>
 					{{ end }}
 				</div>

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -363,6 +363,12 @@ section .column img {
     margin-left: 5px;
 }
 
+.caption {
+    font-style: italic;
+    padding: 6px;
+    text-align: center;
+}
+
 /* Arrow */
 
 .down-arrow {


### PR DESCRIPTION
Currently you can only set a title for an entire image section, but not for images, individually. This is useful, in my opinion, when setting an artist portfolio, to show what the name of a painting is or where a photo was taken.

It just adds a `captions` array, which is optional, but has to be the same length as images. Each caption will be attached to the corresponding image at the same position in the array.

Thank you.