### PR TITLE
feat: add meta description if setup. This improves SEO scoring.

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -5,7 +5,10 @@
 	<meta charset="utf-8" />
 	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
-
+	{{ if .Params.description }}
+	<meta name="description" content="{{ .Params.description }}">
+	{{ end }}
+	
 	{{ if and .Title (not .IsHome) }}
 		<title>{{ .Title }} {{ if .Params.Subtitle }}- {{ .Params.Subtitle }}{{else}}- {{ .Site.Title }}{{ end }}</title>
 	{{ else }}


### PR DESCRIPTION
Hello @boratanrikulu. I am almost done with my site, based on eternity, but Lighthouse is scoring low values because there is no `meta name="description"` in the header. I've created and tested this branch and the results improved a lot with it (from 69 to 85, actually, remaining just non crawable links). It just uses a `description` field in the post template, but it is not mandatory.
For example:
```
---
title: Work
url: work
description: Catalog and recent works
---
```

This will translate into a meta tag:
`<meta name="description" content="Catalog and recent works">`

What do you think? Thank you very much for your work, by the way.