### PR TITLE
docs: Update default config file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Note: If you're an artist who wants to host a website but doesn't have know how 
 
 3. Remove default config file.  
 	```shell
-	rm config.toml
+	rm hugo.toml
 	```  
 
 4. Submodule the theme.  

--- a/README.md
+++ b/README.md
@@ -97,7 +97,11 @@ Note: If you're an artist who wants to host a website but doesn't have know how 
 3. Remove default config file.  
 	```shell
 	rm hugo.toml
-	```  
+	```
+	If you use an older version of Hugo ([< v0.110.0](https://github.com/gohugoio/hugo/issues/8979)), your config might be called differently:
+	```shell
+	rm config.toml
+	```
 
 4. Submodule the theme.  
 	```shell

--- a/example/eternity.bora.sh/content/about.md
+++ b/example/eternity.bora.sh/content/about.md
@@ -45,7 +45,7 @@ hideDate: true
 
 3. Remove default config file.  
 	```shell
-	rm config.toml
+	rm hugo.toml
 	```  
 
 4. Submodule the theme.  

--- a/example/eternity.bora.sh/content/about.md
+++ b/example/eternity.bora.sh/content/about.md
@@ -46,7 +46,11 @@ hideDate: true
 3. Remove default config file.  
 	```shell
 	rm hugo.toml
-	```  
+	```
+	If you use an older version of Hugo ([< v0.110.0](https://github.com/gohugoio/hugo/issues/8979)), your config might be called differently:
+	```shell
+	rm config.toml
+	```
 
 4. Submodule the theme.  
 	```shell


### PR DESCRIPTION
The default config file name was changed from `config.toml` to `hugo.toml` in v0.110.0 (see https://github.com/gohugoio/hugo/issues/8979).
This PR updates the instructions in the `Installation` section of `README.md`.